### PR TITLE
Feature/dual quicker changer

### DIFF
--- a/onrobot_rg_control/CMakeLists.txt
+++ b/onrobot_rg_control/CMakeLists.txt
@@ -40,5 +40,6 @@ catkin_install_python(
 
     nodes/DualChanger/OnRobotRGTcpDualNode.py 
     nodes/DualChanger/OnRobotRGStatusDualListen.py
+    nodes/DualChanger/OnRobotRGDualServer.py
     
     DESTINATION ${CATKIN_PACKAGE_BIN_DESTINATION})

--- a/onrobot_rg_control/CMakeLists.txt
+++ b/onrobot_rg_control/CMakeLists.txt
@@ -37,4 +37,8 @@ catkin_install_python(
     nodes/OnRobotRGStatusListener.py
     nodes/OnRobotRGTcpNode.py
     nodes/OnRobotRGSimpleControllerServer.py
+
+    nodes/DualChanger/OnRobotRGTcpDualNode.py 
+    nodes/DualChanger/OnRobotRGStatusDualListen.py
+    
     DESTINATION ${CATKIN_PACKAGE_BIN_DESTINATION})

--- a/onrobot_rg_control/launch/bringup_dual.launch
+++ b/onrobot_rg_control/launch/bringup_dual.launch
@@ -17,5 +17,6 @@
   <node name="OnRobotRGTcpDualNode"
         pkg="onrobot_rg_control"
         type="OnRobotRGTcpDualNode.py"
+        respawn="True"
         output="screen"/>    
 </launch>

--- a/onrobot_rg_control/launch/bringup_dual.launch
+++ b/onrobot_rg_control/launch/bringup_dual.launch
@@ -1,0 +1,22 @@
+<launch>
+   <arg name="ip"                default="192.168.1.1"/>
+   <arg name="port"              default="502"/>
+   <arg name="gripper_primary"   default="rg2"/>
+   <arg name="gripper_secondary" default="rg6"/>
+   <arg name="dummy"             default="false"/>
+
+   <param name="/onrobot/ip"                value="$(arg ip)" />
+   <param name="/onrobot/port"              value="$(arg port)" />
+   <param name="/onrobot/gripper_primary"   value="$(arg gripper_primary)" />
+   <param name="/onrobot/gripper_secondary" value="$(arg gripper_secondary)" />
+ 
+  <!-- <node name="OnRobotRGStatusDualListen"
+        pkg="onrobot_rg_control"
+        type="OnRobotRGStatusDualListen.py"
+        output="screen"/> -->
+
+  <node name="OnRobotRGTcpDualNode"
+        pkg="onrobot_rg_control"
+        type="OnRobotRGTcpDualNode.py"
+        output="screen"/>    
+</launch>

--- a/onrobot_rg_control/launch/bringup_dual.launch
+++ b/onrobot_rg_control/launch/bringup_dual.launch
@@ -10,11 +10,10 @@
    <param name="/onrobot/gripper_primary"   value="$(arg gripper_primary)" />
    <param name="/onrobot/gripper_secondary" value="$(arg gripper_secondary)" />
  
-  <!-- <node name="OnRobotRGStatusDualListen"
+  <node name="OnRobotRGStatusDualListen"
         pkg="onrobot_rg_control"
         type="OnRobotRGStatusDualListen.py"
-        output="screen"/> -->
-
+        output="screen"/>
   <node name="OnRobotRGTcpDualNode"
         pkg="onrobot_rg_control"
         type="OnRobotRGTcpDualNode.py"

--- a/onrobot_rg_control/nodes/DualChanger/OnRobotRGDualServer.py
+++ b/onrobot_rg_control/nodes/DualChanger/OnRobotRGDualServer.py
@@ -1,0 +1,94 @@
+#!/usr/bin/env python3
+
+import rospy 
+from onrobot_rg_control.msg import OnRobotRGOutput
+from onrobot_rg_control.srv import SetCommand, SetCommandResponse
+
+class OnRobotRGDualNode:
+    def __init__(self):
+        self.pub_primary_gripper = rospy.Publisher('OnRobotRG_Output_A', OnRobotRGOutput, queue_size=1)
+        self.pub_secondary_gripper = rospy.Publisher('OnRobotRG_Output_B', OnRobotRGOutput, queue_size=1)
+
+        self.commandA = OnRobotRGOutput()
+        self.commandB = OnRobotRGOutput()
+
+        self.set_command_srv_A = rospy.Service(
+            "/onrobot_rg/set_command_A",
+            SetCommand,
+            self.handle_command_A)
+        
+        self.set_command_srv_B = rospy.Service(
+            "/onrobot_rg/set_command_B",
+            SetCommand,
+            self.handle_command_B)
+
+    def handle_command_A(self, req, gripper=0):
+        """To handle sending commands via socket connection."""
+        rospy.loginfo(str(req.command))
+    
+        self.command = self.genCommand(str(req.command), self.command, gtype=gtype_A)
+        self.pub_primary_gripper.publish(self.command)
+        rospy.sleep(1)
+        return SetCommandResponse(
+            success=None,  # TODO: implement
+            message=None)  # TODO: implement
+
+    def handle_command_B(self, req):
+        """To handle sending commands via socket connection."""
+        rospy.loginfo(str(req.command))
+        self.command = self.genCommand(str(req.command), self.command, gtype=gtype_B)
+        self.pub_secondary_gripper.publish(self.command)
+        rospy.sleep(1)
+        return SetCommandResponse(
+            success=None,  # TODO: implement
+            message=None)  # TODO: implement
+    
+
+    def genCommand(self, char, command, gtype):
+        """Updates the command according to the character entered by the user."""
+
+        if gtype == 'rg2':
+            max_force = 400
+            max_width = 1100
+        elif gtype == 'rg6':
+            max_force = 1200
+            max_width = 1600
+        else:
+            rospy.signal_shutdown(
+                rospy.get_name() +
+                ": Select the gripper type from rg2 or rg6.")
+
+        if char == 'c':
+            command.rGFR = max_force
+            command.rGWD = 0
+            command.rCTR = 16
+        elif char == 'o':
+            command.rGFR = max_force
+            command.rGWD = max_width
+            command.rCTR = 16
+        elif char == 'i':
+            command.rGFR += 25
+            command.rGFR = min(max_force, command.rGFR)
+            command.rCTR = 16
+        elif char == 'd':
+            command.rGFR -= 25
+            command.rGFR = max(0, command.rGFR)
+            command.rCTR = 16
+        else:
+            # If the command entered is a int, assign this value to rGWD
+            try:
+                command.rGFR = max_force
+                command.rGWD = min(max_width, int(char))
+                command.rCTR = 16
+            except ValueError:
+                pass
+
+        return command
+
+if __name__ == '__main__':
+    gtype_A = rospy.get_param('/onrobot/gripper_primary', 'rg2')
+    gtype_B = rospy.get_param('/onrobot/gripper_secondary', 'rg6')
+    rospy.init_node(
+        'OnRobotRGSimpleControllerServer', anonymous=True, log_level=rospy.DEBUG)
+    node = OnRobotRGDualNode()
+    rospy.spin()

--- a/onrobot_rg_control/nodes/DualChanger/OnRobotRGDualServer.py
+++ b/onrobot_rg_control/nodes/DualChanger/OnRobotRGDualServer.py
@@ -22,11 +22,11 @@ class OnRobotRGDualNode:
             SetCommand,
             self.handle_command_B)
 
-    def handle_command_A(self, req, gripper=0):
+    def handle_command_A(self, req):
         """To handle sending commands via socket connection."""
         rospy.loginfo(str(req.command))
     
-        self.command = self.genCommand(str(req.command), self.command, gtype=gtype_A)
+        self.command = self.genCommand(str(req.command), self.commandA, gtype=gtype_A)
         self.pub_primary_gripper.publish(self.command)
         rospy.sleep(1)
         return SetCommandResponse(
@@ -36,7 +36,7 @@ class OnRobotRGDualNode:
     def handle_command_B(self, req):
         """To handle sending commands via socket connection."""
         rospy.loginfo(str(req.command))
-        self.command = self.genCommand(str(req.command), self.command, gtype=gtype_B)
+        self.command = self.genCommand(str(req.command), self.commandB, gtype=gtype_B)
         self.pub_secondary_gripper.publish(self.command)
         rospy.sleep(1)
         return SetCommandResponse(

--- a/onrobot_rg_control/nodes/DualChanger/OnRobotRGDualServer.py
+++ b/onrobot_rg_control/nodes/DualChanger/OnRobotRGDualServer.py
@@ -5,6 +5,7 @@ from onrobot_rg_control.msg import OnRobotRGOutput
 from onrobot_rg_control.srv import SetCommand, SetCommandResponse
 
 class OnRobotRGDualNode:
+    """Class to handle setting commands for dual gripper."""
     def __init__(self):
         self.pub_primary_gripper = rospy.Publisher('OnRobotRG_Output_A', OnRobotRGOutput, queue_size=1)
         self.pub_secondary_gripper = rospy.Publisher('OnRobotRG_Output_B', OnRobotRGOutput, queue_size=1)
@@ -23,7 +24,7 @@ class OnRobotRGDualNode:
             self.handle_command_B)
 
     def handle_command_A(self, req):
-        """To handle sending commands via socket connection."""
+        """To handle sending Primary Gripper commands via socket connection."""
         rospy.loginfo(str(req.command))
     
         self.command = self.genCommand(str(req.command), self.commandA, gtype=gtype_A)
@@ -34,7 +35,7 @@ class OnRobotRGDualNode:
             message=None)  # TODO: implement
 
     def handle_command_B(self, req):
-        """To handle sending commands via socket connection."""
+        """To handle sending Secondary Gripper commands via socket connection."""
         rospy.loginfo(str(req.command))
         self.command = self.genCommand(str(req.command), self.commandB, gtype=gtype_B)
         self.pub_secondary_gripper.publish(self.command)
@@ -89,6 +90,6 @@ if __name__ == '__main__':
     gtype_A = rospy.get_param('/onrobot/gripper_primary', 'rg2')
     gtype_B = rospy.get_param('/onrobot/gripper_secondary', 'rg6')
     rospy.init_node(
-        'OnRobotRGSimpleControllerServer', anonymous=True, log_level=rospy.DEBUG)
+        'OnRobotRGDualServer', anonymous=True, log_level=rospy.DEBUG)
     node = OnRobotRGDualNode()
     rospy.spin()

--- a/onrobot_rg_control/nodes/DualChanger/OnRobotRGStatusDualListen.py
+++ b/onrobot_rg_control/nodes/DualChanger/OnRobotRGStatusDualListen.py
@@ -3,40 +3,49 @@
 import rospy
 from onrobot_rg_control.msg import OnRobotRGInput
 
-def Status_A_callback(status):
-    statusA.gFOF = status.gFOF
-    statusA.gGWD = status.gGWD
-    statusA.gSTA = status.gSTA
-    statusA.gWDF = status.gWDF
+class DualGripperListen:
+    def __init__(self):
+        self.statusA = OnRobotRGInput
+        self.statusB = OnRobotRGInput
 
-def Status_B_callback(status):
-    statusB.gFOF = status.gFOF
-    statusB.gGWD = status.gGWD
-    statusB.gSTA = status.gSTA
-    statusB.gWDF = status.gWDF
-
-def status_interpreter():
-    output = '\n-----\nOnRobot Dual Changer RG status interpreter\n-----\n'
-    output += 'Gripper STATUS \n PRIMARY | SECONDARY\n'
-    output += 'status_A = ' + str(statusA.gSTA) + '   status_B = ' + str(statusA.gSTA) + '\n'
+        #Subscribers
+        rospy.Subscriber("OnRobotRG_Input_A", OnRobotRGInput, self.Status_A_callback)
+        rospy.Subscriber("OnRobotRG_Input_B", OnRobotRGInput, self.Status_B_callback)
+        
     
-    output += 'Current width between the gripper fingers (w/o offset): ' + \
-              str(statusA.gGWD / 10.0) + ' mm\n' + '  ' + str(statusB.gGWD / 10.0) + ' mm\n'
+    def Status_A_callback(self, status):
+        self.statusA = status
 
-def OnRobotRGStatusListener():
-    """Initializes the node and subscribe to both grippers OnRobotRGInput topics."""
+    def Status_B_callback(self, status):
+        self.statusB = status
 
-    rospy.init_node(
-        'OnRobotRGStatusDualListen', anonymous=True, log_level=rospy.DEBUG)
-    rospy.Subscriber("OnRobotRGInput_A", OnRobotRGInput, Status_A_callback)
-    rospy.Subscriber("OnRobotRGInput_B", OnRobotRGInput, Status_B_callback)
+    def status_interpreter(self):
 
-    rospy.loginfo(status_interpreter())
+         while not rospy.is_shutdown():
+            output = '\n-----\nOnRobot Dual Changer RG status interpreter\n-----\n'
+            output += 'Gripper DUAL CHANGER STATUS \n '
+            output += '\n ------PRIMARY------ \n'
+            output += 'Status_A = ' + str(self.statusA.gSTA) + '\n'
+            output += ' Width_A = ' + \
+                        str(self.statusA.gWDF) + ' mm\n'
+            output += 'Offset_A = ' + \
+                        str(self.statusA.gFOF) + ' mm\n'
 
-    rospy.spin()
+            output += '\n------SECONDARY------ \n'
+            output += 'Status_B = ' + str(self.statusB.gSTA) +'\n'
+            output += ' Width_B = ' + \
+                        str(self.statusB.gWDF) + ' mm\n'
+            output += 'Offset_B = ' + \
+                        str(self.statusA.gFOF) + ' mm\n'
+
+            rospy.loginfo(output)
 
 if __name__ == '__main__':
-    statusA = OnRobotRGInput  
-    statusB = OnRobotRGInput
+    try:
+        rospy.init_node('OnRobotRGStatusDualListen')
 
-    OnRobotRGStatusListener()
+        rate = rospy.Rate(20) # 20Hz
+        Listener = DualGripperListen()
+        Listener.status_interpreter()
+    except rospy.ROSInterruptException:
+        pass

--- a/onrobot_rg_control/nodes/DualChanger/OnRobotRGStatusDualListen.py
+++ b/onrobot_rg_control/nodes/DualChanger/OnRobotRGStatusDualListen.py
@@ -1,0 +1,42 @@
+#!/usr/bin/env python3
+
+import rospy
+from onrobot_rg_control.msg import OnRobotRGInput
+
+def Status_A_callback(status):
+    statusA.gFOF = status.gFOF
+    statusA.gGWD = status.gGWD
+    statusA.gSTA = status.gSTA
+    statusA.gWDF = status.gWDF
+
+def Status_B_callback(status):
+    statusB.gFOF = status.gFOF
+    statusB.gGWD = status.gGWD
+    statusB.gSTA = status.gSTA
+    statusB.gWDF = status.gWDF
+
+def status_interpreter():
+    output = '\n-----\nOnRobot Dual Changer RG status interpreter\n-----\n'
+    output += 'Gripper STATUS \n PRIMARY | SECONDARY\n'
+    output += 'status_A = ' + str(statusA.gSTA) + '   status_B = ' + str(statusA.gSTA) + '\n'
+    
+    output += 'Current width between the gripper fingers (w/o offset): ' + \
+              str(statusA.gGWD / 10.0) + ' mm\n' + '  ' + str(statusB.gGWD / 10.0) + ' mm\n'
+
+def OnRobotRGStatusListener():
+    """Initializes the node and subscribe to both grippers OnRobotRGInput topics."""
+
+    rospy.init_node(
+        'OnRobotRGStatusDualListen', anonymous=True, log_level=rospy.DEBUG)
+    rospy.Subscriber("OnRobotRGInput_A", OnRobotRGInput, Status_A_callback)
+    rospy.Subscriber("OnRobotRGInput_B", OnRobotRGInput, Status_B_callback)
+
+    rospy.loginfo(status_interpreter())
+
+    rospy.spin()
+
+if __name__ == '__main__':
+    statusA = OnRobotRGInput  
+    statusB = OnRobotRGInput
+
+    OnRobotRGStatusListener()

--- a/onrobot_rg_control/nodes/DualChanger/OnRobotRGTcpDualNode.py
+++ b/onrobot_rg_control/nodes/DualChanger/OnRobotRGTcpDualNode.py
@@ -1,0 +1,73 @@
+#!/usr/bin/env python3
+
+import rospy
+import onrobot_rg_modbus_tcp.comModbusTcp
+import onrobot_rg_control.baseOnRobotRG
+from onrobot_rg_control.msg import OnRobotRGInput
+from onrobot_rg_control.msg import OnRobotRGOutput
+
+def mainLoop():
+    #Daual quicker changer addresses for primary and secondary side using ModBus/TCP
+    primary_address = 66 #0x42
+    secondary_address = 67 #0x43
+
+    # Primary side Gripper on Dual Changer Connection
+    gripper_primary = onrobot_rg_control.baseOnRobotRG.onrobotbaseRG(gtype_prime)
+    gripper_primary.client = onrobot_rg_modbus_tcp.comModbusTcp.communication(dummy)
+    gripper_primary.client.connectToDevice(ip, port, primary_address)
+
+    # Secondary side Gripper on Dual changer Connection
+    gripper_secondary = onrobot_rg_control.baseOnRobotRG.onrobotbaseRG(gtype_second)
+    gripper_secondary.client = onrobot_rg_modbus_tcp.comModbusTcp.communication(dummy)
+    gripper_secondary.client.connectToDevice(ip, port, secondary_address)
+
+    #Initialize Node
+    rospy.init_node(
+        'OnRobotRGTcpDual', anonymous=True, log_level=rospy.DEBUG)
+
+    #Grippers Status publish
+    pub_primary_gripper = rospy.Publisher('OnRobotRG_Input_A', OnRobotRGInput, queue_size=1)
+    pub_secondary_gripper = rospy.Publisher('OnRobotRG_Input_B', OnRobotRGInput, queue_size=1)
+
+    #Gripper Commandds reception
+    rospy.Subscriber('OnRobotRG_Output_A', OnRobotRGOutput, gripper_primary.refreshCommand)
+    rospy.Subscriber('OnRobotRG_Output_B', OnRobotRGOutput, gripper_secondary.refreshCommand)
+
+    #Loop 
+    prev_msg_prime = []
+    prev_msg_second = []
+    while not rospy.is_shutdown():
+        #Get Grippers Status
+        status_primary = gripper_primary.getStatus()
+        status_secondary = gripper_secondary.getStatus()
+        #Publish Status
+        pub_primary_gripper.publish(status_primary)
+        pub_secondary_gripper.publish(status_secondary)
+
+        rospy.sleep(0.05)
+        #Update Command primary side
+        if not int(format(status_primary.gSTA, '016b')[-1]): #If not busy
+            if not prev_msg_prime == gripper_primary.message: #Get new messages
+                rospy.loginfo(rospy.get_name()+": Sending Message A Side")
+                gripper_primary.sendCommand()
+            prev_msg_prime = gripper_primary.message
+        
+        #Update Command secondary side
+        if not int(format(status_secondary.gSTA, '016b')[-1]): #If not busy
+            if not prev_msg_second == gripper_secondary.message: #Get new messages
+                rospy.loginfo(rospy.get_name()+": Sending Message B Side")
+                gripper_secondary.sendCommand()
+            prev_msg_second = gripper_secondary.message
+
+            rospy.sleep(0.05)
+
+if __name__ == '__main__':
+    try:
+        ip = rospy.get_param('/onrobot/ip', '192.168.1.1')
+        port = rospy.get_param('/onrobot/port', '502')
+        gtype_prime = rospy.get_param('/onrobot/gripper_primary', 'rg2')
+        gtype_second = rospy.get_param('/onrobot/gripper_secondary', 'rg6')
+        dummy = rospy.get_param('/onrobot/dummy', False)
+        mainLoop()
+    except rospy.ROSInterruptException:
+        pass

--- a/onrobot_rg_control/nodes/DualChanger/README.md
+++ b/onrobot_rg_control/nodes/DualChanger/README.md
@@ -1,0 +1,47 @@
+# onrobot
+
+
+ROS nodes for DUAL Quicker Changer  <br />
+RG2/RG6 OnRobot Grippers 
+
+
+## Usage
+
+1. Connect the cable between Compute Box and Dual Tool Changer
+2. Connect an ethernet cable between Compute Box and your computer
+3. Execute programs
+
+### RG2 / RG6
+#### Default configuration     <br />
+RG2 - Primary Side   (1)  <br />
+RG6 - Secondary Side (2)
+
+#### Send motion commands
+
+
+##### ROS service call
+```
+roslaunch onrobot_rg_control bringup_dual.launch ip:=XXX.XXX.XXX.XXX gripper_primary:=rg2 gripper_secondary:=rg6
+
+rosrun onrobot_rg_control OnRobotRGDualServer.py
+```
+ ##### Control primary Gripper
+```
+rosservice call /onrobot_rg/set_command_A 'c'
+rosservice call /onrobot_rg/set_command_A 'o'
+rosservice call /onrobot_rg/set_command_A '!!str 300'
+```
+##### Control secondary Gripper
+```
+rosservice call /onrobot_rg/set_command_B 'c'
+rosservice call /onrobot_rg/set_command_B 'o'
+rosservice call /onrobot_rg/set_command_B '!!str 300'
+```
+
+## Author / Contributor
+
+
+
+## License
+
+This software is released under the MIT License, see [LICENSE](./LICENSE).


### PR DESCRIPTION

### New Feature Submissions:

## Dual Quicker changer nodes to control both grippers at the same time
Codes adaptation to working with two grippers simultaneously, which are on **DualChanger folder** inside **onrobot_rg_control/Nodes**
1. [x] **OnRobotRGTcpDualNode**.py : Manage two instances of grippers to publish and subscribe to both or them
2. [x] **OnRobotRGStatusDualListen**.py: Reads data for both grippers and display in terminal
3. [x] **OnRobotRGDualServer**.py: Enable two ros services, one for each gripper
4. [x] **Bringup_dual**.launch: Runs TcpDual and StatusDual Listener nodes

### Changes to Core Features:

* [x] Edit CMakeLists.txt to add python scripts

### Notes
* [x] Is currently on the external DualChanger folder for testing, but eventually can replace the previous nodes
* [x] Bringup_dual runs respawn nodes, for future restart power cycle implementation
