### PR TITLE
ResetPowerCycle node 

### DIFF
--- a/onrobot_rg_control/CMakeLists.txt
+++ b/onrobot_rg_control/CMakeLists.txt
@@ -36,5 +36,6 @@ catkin_install_python(
     nodes/OnRobotRGSimpleController.py
     nodes/OnRobotRGStatusListener.py
     nodes/OnRobotRGTcpNode.py
+    nodes/OnRobotRGReset.py
     nodes/OnRobotRGSimpleControllerServer.py
     DESTINATION ${CATKIN_PACKAGE_BIN_DESTINATION})

--- a/onrobot_rg_control/launch/bringup.launch
+++ b/onrobot_rg_control/launch/bringup.launch
@@ -18,5 +18,6 @@
   <node name="OnRobotRGTcpNode"
         pkg="onrobot_rg_control"
         type="OnRobotRGTcpNode.py"
+        respawn="True"
         output="screen"/>
 </launch>

--- a/onrobot_rg_control/nodes/OnRobotRGReset.py
+++ b/onrobot_rg_control/nodes/OnRobotRGReset.py
@@ -1,0 +1,23 @@
+#!/usr/bin/env python3
+
+import rospy
+import onrobot_rg_modbus_tcp.comModbusTcp
+import onrobot_rg_control.baseOnRobotRG
+
+def mainLoop():
+    # Gripper is a RG gripper with a Modbus/TCP connection
+    gripper = onrobot_rg_control.baseOnRobotRG
+    gripper.client = onrobot_rg_modbus_tcp.comModbusTcp.communication()
+    
+    #Initialize connection to Compute Box
+    restart_address = 63 #0x3F
+    gripper.client.connectToDevice(ip, port, restart_address)
+    gripper.client.restartPowerCycle()
+
+if __name__ == '__main__':
+    try:
+        ip = rospy.get_param('/onrobot/ip', '192.168.1.1')
+        port = rospy.get_param('/onrobot/port', '502')
+        mainLoop()
+    except rospy.ROSInterruptException:
+        pass

--- a/onrobot_rg_modbus_tcp/src/onrobot_rg_modbus_tcp/comModbusTcp.py
+++ b/onrobot_rg_modbus_tcp/src/onrobot_rg_modbus_tcp/comModbusTcp.py
@@ -68,6 +68,19 @@ class communication:
                 self.client.write_registers(
                     address=0, values=message, unit=self.changer_addr)
 
+    def restartPowerCycle(self):
+        """ Restart Power Cycle of Compute Box
+            Necessary is Safety Switch of RG2 or RG6 are pressed
+            Writing 2 to this field powers the tool off for a short amount of time and then powers them back
+        """
+        message = 2
+        restart_address = 63
+        
+        # Sending 2 to address 0x0 resets compute box (address 63) power cycle
+        with self.lock:
+                self.client.write_registers(
+                    address=0, values=message, unit=restart_address)
+
     def getStatus(self):
         """Sends a request to read, wait for the response
            and returns the Gripper status.


### PR DESCRIPTION
### New Feature Submissions:
#### Feature/RestartPowerCycle ROS Node:

1. [x] **OnRobotRGReset.py :** Node that sends message(2)  to compute box address (63) to restart power cycle. It is necessary if safety switchs are enabled. It needs to be run after bringup_launch so it uses IP and Port params to start communication.

                       `rosrun onrobot_rg_control OnRobotRGReset.py `

### Changes to Core Features:

* [x] **comModbusTcp.py:** restartPowerCycle function added, to send message through Modbus TCP
* [x] **bringup.launch:** TCPNode is now respawn, which makes restart automatically if fails. It is necessary when compute box is restarted 
* [x] CMakeLists.txt: Added OnRobotRGReset node

### TODO:
* [x] Make RosService instead of Node, to better implementation on user software
* [x] Probably add that RosService on OnRobotRGSimpleControllerServer.py to start both services at the same time.

### Comments:


REFERENCES

![image](https://user-images.githubusercontent.com/31255217/203799459-49bc80c7-3bb9-45d9-a853-442393a330b2.png)

![image](https://user-images.githubusercontent.com/31255217/203799618-216d09cd-6101-424c-a56d-1e6dc689e3f0.png)

