### PR TITLE
missing prev_msg assignment in the mainLoop for vg node

### DIFF
--- a/onrobot_vg_control/nodes/OnRobotVGTcpNode.py
+++ b/onrobot_vg_control/nodes/OnRobotVGTcpNode.py
@@ -54,6 +54,7 @@ class OnRobotVGTcp:
             if not prev_msg == self.gripper.message:  # find new message
                 rospy.loginfo(rospy.get_name()+": Sending message.")
                 self.gripper.sendCommand()
+            prev_msg = self.gripper.message
             rospy.sleep(0.05)
 
 


### PR DESCRIPTION
prev_msg assignment is missing for the VG node, resulting command being sent and printed every iteration.